### PR TITLE
v1.8 Add optional variable buildspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module "ecs_pipeline" {
 | task\_execution\_role | The name of the task execution role | string | `"ecsTaskExecutionRole"` | no |
 | github\_oauth\_token | GitHub oauth token | string | n/a | yes |
 | codebuild\_image | The codebuild image to use | string | `"null"` | no |
+| buildspec | build spec file other than buildspec.yml | string | `"buildspec.yml"` | no |
 | ecs\_artifact\_filename | The name of the ECS deploy artifact | string | `"null"` | no |
 | github\_branch\_name | The git branch name to use for the codebuild project | string | `"master"` | no |
 | use\_docker\_credentials | \(Optional\) Use dockerhub credentals stored in parameter store | bool | false | no |

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "codebuild_project" {
   deploy_type            = "ecs"
   ecr_name               = var.ecr_name
   use_docker_credentials = var.use_docker_credentials
+  buildspec              = var.buildspec
   tags                   = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,9 @@ variable "tags" {
   description = "A mapping of tags to assign to the resource"
   default     = {}
 }
+
+variable "buildspec" {
+  type        = string
+  description = "build spec file other than buildspec.yml"
+  default     = "buildspec.yml"
+}


### PR DESCRIPTION
#### PR description

What is it for?
Add optional variable `buildspec` used in the aws-codebuild-project terraform module.

#### Testing instructions

- import module v1.8 in other terraform projects.

#### JIRA ticket information

Story: [AHP-312](https://jira.theglobeandmail.com/browse/AHP-312)