### PR TITLE
v2.1 Upgrade codebuild_project Module Version to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ module "ecs_pipeline" {
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
 | use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
 | svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
-| svcs\_account\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token or var.use\_sysdig\_api\_token is true. | `string` | `null` | no |yes |
+| svcs\_account\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token or var.use\_sysdig\_api\_token is true. | `string` | `null` | no | yes |
 | create\_github\_webhook | Create the github webhook that triggers codepipeline | bool | `"true"` | no |
 | s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
 | use\_sysdig\_api\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the SYSDIG\_API\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -32,11 +32,22 @@ If `use_repo_access_github_token` is set to `true`, the environment variable `RE
 Usage remains the same as v1.9.
 If `s3_block_public_access` is set to `true`, the block public access setting for the artifact bucket is enabled.
 
+
+## v.2.1 Note
+If `use_sysdig_api_token` is set to `true`, the secrets manager environment variable `SYSDIG_API_TOKEN_SECRETS_ID` is exposed via codebuild.
+
+You can add the 1 line to the beginning of your `build` phase commands in `buildspec.yml` to assign the token's secret value to local variable `SYSDIG_API_TOKEN`.
+```yml
+  build:
+    commands:
+      - export SYSDIG_API_TOKEN=${SYSDIG_API_TOKEN_SECRETS_ID}
+```
+
 ## Usage
 
 ```hcl
 module "ecs_pipeline" {
-  source = "github.com/globeandmail/aws-codepipeline-ecs?ref=1.11"
+  source = "github.com/globeandmail/aws-codepipeline-ecs?ref=2.1"
 
   name               = "app-name"
   ecr_name           = "ecr-repo-name"
@@ -48,10 +59,12 @@ module "ecs_pipeline" {
   tags = {
     Environment = var.environment
   }
-  use_repo_access_github_token = true
-  svcs_account_github_token_aws_secret_arn = svcs-account-github-token-aws-secret-arn
-  svcs_account_github_token_aws_kms_cmk_arn = svcs-account-github-token-aws-kms-cmk-arn
-  s3_block_public_access = true
+  use_repo_access_github_token                 = true
+  svcs_account_github_token_aws_secret_arn     = svcs-account-github-token-aws-secret-arn
+  svcs_account_aws_kms_cmk_arn                 = svcs-account-aws-kms-cmk-arn
+  s3_block_public_access                       = true
+  use_sysdig_api_token                         = true
+  svcs_account_sysdig_api_token_aws_secret_arn = svcs-account-sysdig-api-token-aws-secret-arn
 }
 ```
 
@@ -76,9 +89,11 @@ module "ecs_pipeline" {
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
 | use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
 | svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
-| svcs\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |yes |
+| svcs\_account\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token or var.use\_sysdig\_api\_token is true. | `string` | `null` | no |yes |
 | create\_github\_webhook | Create the github webhook that triggers codepipeline | bool | `"true"` | no |
 | s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
+| use\_sysdig\_api\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the SYSDIG\_API\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
+| svcs\_account\_sysdig\_api\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the sysdig API token.<br>The secret is created in the shared service account.<br>Required if var.use\_sysdig\_api\_token is true. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=AHP-1113" # change to tag 2.0
 
   name                                         = var.name
   deploy_type                                  = "ecs"
@@ -24,8 +24,10 @@ module "codebuild_project" {
   tags                                         = var.tags
   use_repo_access_github_token                 = var.use_repo_access_github_token
   svcs_account_github_token_aws_secret_arn     = var.svcs_account_github_token_aws_secret_arn
-  svcs_account_github_token_aws_kms_cmk_arn    = var.svcs_account_github_token_aws_kms_cmk_arn
+  svcs_account_aws_kms_cmk_arn                 = var.svcs_account_aws_kms_cmk_arn
   s3_block_public_access                       = var.s3_block_public_access
+  use_sysdig_api_token                         = var.use_sysdig_api_token
+  svcs_account_sysdig_api_token_aws_secret_arn = var.svcs_account_sysdig_api_token_aws_secret_arn
 }
 
 data "aws_iam_policy_document" "codepipeline_assume" {

--- a/variables.tf
+++ b/variables.tf
@@ -100,12 +100,12 @@ variable "svcs_account_github_token_aws_secret_arn" {
   default     = null
 }
 
-variable "svcs_account_github_token_aws_kms_cmk_arn" {
+variable "svcs_account_aws_kms_cmk_arn" {
   type        = string
   description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.
                 The key is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
+                Required if var.use_repo_access_github_token or var.use_sysdig_api_token is true.
                 EOT
   default     = null
 }
@@ -120,4 +120,23 @@ variable "s3_block_public_access" {
   type = bool
   description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
   default = false
+}
+
+variable "use_sysdig_api_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the SYSDIG_API_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
+}
+
+variable "svcs_account_sysdig_api_token_aws_secret_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The AWS secret ARN for the sysdig API token.
+                The secret is created in the shared service account.
+                Required if var.use_sysdig_api_token is true.
+                EOT
+  default     = null
 }


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to add the optional variables `use_sysdig_api_token` and `svcs_account_sysdig_api_token_aws_secret_arn`.
The AWS secret is in the ds-ml-shared-svcs-prod AWS account.
The API token is for Sysdig image scanning.
Also renamed optional variable `svcs_account_aws_kms_cmk_arn`.
Upgraded `codebuild_project` module version to branch AHP-1113, which later will be tag version 2.0.
 
#### Testing instructions

- Verify that the new module version 2.1 is deployable in the mutli-tenant AWS accounts.

#### JIRA ticket information

Story: [AHP-1113](https://jira.theglobeandmail.com/browse/AHP-1113)